### PR TITLE
add setup.py to allow easy install and packaging

### DIFF
--- a/NitroKey.py
+++ b/NitroKey.py
@@ -101,7 +101,7 @@ class NitroKey(object):
 		self._call(cmd)
 
 	def explore(self):
-		if self._verbose:
+		if self.__verbose:
 			print("Verify PIN   : verify chv129")
 			print("Change PIN   : change chv129 \"648219\" \"123456\"")
 			print("Change SO-PIN: change chv136 \"3537363231383830\" \"16b72e4528d5063e\"")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name = 'nitrotool',
+    description='Easy handling of NitroKey HSM USB Smard Card',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author='@johndoe31415',
+    url='https://github.com/johndoe31415/nitrotool',
+    license='GPL-3.0',
+    keywords="nitrokey hsm smardcard",
+    scripts = [ 'nitrotool' ],
+    py_modules=[
+        'ActionChangePIN',
+        'ActionCheckEngine',
+        'ActionExplore',
+        'ActionFormat',
+        'ActionGenCSR',
+        'ActionGetPublicKey',
+        'ActionIdentify',
+        'ActionInit',
+        'ActionKeyGen',
+        'ActionPutCRT',
+        'ActionRemoveKey',
+        'ActionUnblock',
+        'ActionVerifyPIN',
+        'BaseAction',
+        'CmdTools',
+        'FriendlyArgumentParser',
+        'MultiCommand',
+        'NitroKey',
+        'PrefixMatcher',
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: Unix",
+    ],
+)


### PR DESCRIPTION
I'm planning on packaging this tool for Debian, and its much easier if
the project has a setup.py.  Also, users can do `pip install -e .` or
you could also publish this tool to pypi.org with this.

After merging this, it would be helpful to also have a tagged release
that matches the version in the setup.py.